### PR TITLE
Fix blog links and skills section

### DIFF
--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -141,6 +141,48 @@ const blogPostsMetadata: Record<string, Omit<BlogPost, 'content'>> = {
     gradient: "from-cyan-500 via-teal-500 to-emerald-600",
     views: 0,
     featured: true
+  },
+  "building-intelligent-chatbot-aws-bedrock": {
+    id: "10",
+    title: "Building an Intelligent Chatbot with AWS Bedrock",
+    excerpt: "Learn how to build an intelligent Q&A system using AWS Bedrock with RAG architecture, vector embeddings, and PGVector for contextual responses.",
+    date: "2024-10-15",
+    tags: ["AWS", "AI", "Python", "RAG", "Vector Embeddings"],
+    readingTime: 8,
+    slug: "building-intelligent-chatbot-aws-bedrock",
+    category: 'technical' as const,
+    image: "https://images.unsplash.com/photo-1677442136019-21780ecad995?w=1920&q=80",
+    gradient: "from-purple-600 via-pink-600 to-indigo-600",
+    views: 0,
+    featured: true
+  },
+  "enterprise-resource-management-system": {
+    id: "11",
+    title: "Building an Enterprise Resource Management System",
+    excerpt: "How we built a comprehensive resource management platform supporting 17 UN-Habitat team members with real-time collaboration and task tracking.",
+    date: "2024-09-20",
+    tags: ["Next.js", "React", "TypeScript", "Real-time", "Airtable"],
+    readingTime: 10,
+    slug: "enterprise-resource-management-system",
+    category: 'technical' as const,
+    image: "https://images.unsplash.com/photo-1611224923853-80b023f02d71?w=1920&q=80",
+    gradient: "from-blue-600 via-cyan-600 to-teal-600",
+    views: 0,
+    featured: true
+  },
+  "ai-powered-portfolio-development": {
+    id: "12",
+    title: "AI-Powered Portfolio Development with MCP Servers",
+    excerpt: "How I built a modern portfolio website using AI-powered development tools, MCP servers, and systematic task management to optimize productivity and code quality.",
+    date: "2025-01-20",
+    tags: ["Next.js", "MCP", "Claude AI", "TaskMaster", "Portfolio"],
+    readingTime: 12,
+    slug: "ai-powered-portfolio-development",
+    category: 'technical' as const,
+    image: "https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?w=1920&q=80",
+    gradient: "from-violet-600 via-purple-600 to-pink-600",
+    views: 0,
+    featured: true
   }
 }
 

--- a/components/SkillsShowcase.tsx
+++ b/components/SkillsShowcase.tsx
@@ -24,57 +24,30 @@ const skills: Skill[] = [
   { name: "Boto3", level: "intermediate", category: "languages" },
   { name: "SQL/PostgreSQL", level: "expert", category: "languages" },
   { name: "HTML/CSS", level: "expert", category: "languages" },
-  { name: "Java", level: "intermediate", category: "languages" },
   
   // AI & Development Tools
   { name: "Claude AI/Claude Code", level: "expert", category: "ai" },
   { name: "Cursor AI", level: "expert", category: "ai" },
-  { name: "Windsurf AI", level: "expert", category: "ai" },
-  { name: "Zed AI", level: "expert", category: "ai" },
   { name: "AWS Bedrock", level: "intermediate", category: "ai" },
   { name: "RAG/Embeddings", level: "intermediate", category: "ai" },
   { name: "MCP (Model Context Protocol)", level: "expert", category: "ai" },
   { name: "ChatGPT/OpenAI API", level: "expert", category: "ai" },
   { name: "Prompt Engineering", level: "expert", category: "ai" },
-  { name: "LangChain", level: "intermediate", category: "ai" },
-  { name: "Streamlit", level: "intermediate", category: "ai" },
-  { name: "PyTorch", level: "intermediate", category: "ai" },
-  { name: "Transformers", level: "intermediate", category: "ai" },
   
   // Other Tools
   { name: "GitHub/GitHub Actions", level: "expert", category: "tools" },
-  { name: "Git", level: "advanced", category: "tools" },
   { name: "N8N.io", level: "advanced", category: "tools" },
   { name: "Postman", level: "advanced", category: "tools" },
   { name: "Figma", level: "advanced", category: "tools" },
   { name: "IAM Security", level: "expert", category: "tools" },
-  { name: "Airtable", level: "expert", category: "tools" },
-  { name: "Vercel", level: "advanced", category: "tools" },
-  { name: "MongoDB", level: "intermediate", category: "tools" },
-  
-  // Mobile & Automation
-  { name: "Apple Shortcuts", level: "expert", category: "mobile" },
-  { name: "iOS Development", level: "advanced", category: "mobile" },
-  { name: "Android Development", level: "advanced", category: "mobile" },
-  { name: "Swift", level: "intermediate", category: "mobile" },
-  { name: "Kotlin", level: "intermediate", category: "mobile" },
-  
-  // Web Development
-  { name: "JavaScript", level: "advanced", category: "web" },
-  { name: "TypeScript", level: "advanced", category: "web" },
-  { name: "React", level: "advanced", category: "web" },
-  { name: "Next.js", level: "advanced", category: "web" },
-  { name: "Node.js", level: "advanced", category: "web" },
-  { name: "Tailwind CSS", level: "advanced", category: "web" }
+  { name: "Apple Shortcuts", level: "expert", category: "tools" }
 ]
 
 const categories = {
   cloud: "Cloud & Infrastructure",
   languages: "Languages & Libraries",
   ai: "AI & Development Tools",
-  tools: "Other Tools",
-  mobile: "Mobile & Automation",
-  web: "Web Development"
+  tools: "Other Tools"
 }
 
 export function SkillsShowcase() {

--- a/components/SkillsShowcase.tsx
+++ b/components/SkillsShowcase.tsx
@@ -4,56 +4,77 @@ import { Skill } from "@/types"
 import { useEffect, useRef, useState } from "react"
 
 const skills: Skill[] = [
-  // Expert level (4)
-  { name: "Claude AI", level: "expert", category: "ai" },
+  // Cloud & Infrastructure
+  { name: "AWS S3", level: "expert", category: "cloud" },
+  { name: "AWS Glue", level: "expert", category: "cloud" },
+  { name: "AWS EventBridge", level: "advanced", category: "cloud" },
+  { name: "AWS Athena", level: "intermediate", category: "cloud" },
+  { name: "AWS QuickSight", level: "intermediate", category: "cloud" },
+  { name: "AWS Lambda", level: "advanced", category: "cloud" },
+  { name: "AWS Step Functions", level: "advanced", category: "cloud" },
+  { name: "CloudWatch", level: "intermediate", category: "cloud" },
+  { name: "Terraform", level: "intermediate", category: "cloud" },
+  { name: "Docker", level: "intermediate", category: "cloud" },
+  
+  // Languages & Libraries
+  { name: "Python", level: "intermediate", category: "languages" },
+  { name: "PySpark", level: "intermediate", category: "languages" },
+  { name: "JSON", level: "advanced", category: "languages" },
+  { name: "Pandas", level: "intermediate", category: "languages" },
+  { name: "Boto3", level: "intermediate", category: "languages" },
+  { name: "SQL/PostgreSQL", level: "expert", category: "languages" },
+  { name: "HTML/CSS", level: "expert", category: "languages" },
+  { name: "Java", level: "intermediate", category: "languages" },
+  
+  // AI & Development Tools
+  { name: "Claude AI/Claude Code", level: "expert", category: "ai" },
   { name: "Cursor AI", level: "expert", category: "ai" },
   { name: "Windsurf AI", level: "expert", category: "ai" },
   { name: "Zed AI", level: "expert", category: "ai" },
-  { name: "MCP Tools (80+ servers)", level: "expert", category: "ai" },
-  { name: "Python", level: "expert", category: "programming" },
-  { name: "Airtable", level: "expert", category: "cloud" },
-  { name: "AI Development", level: "expert", category: "ai" },
-  { name: "Rapid Prototyping", level: "expert", category: "ai" },
-  { name: "AI Agent (LangChain, N8N)", level: "expert", category: "ai" },
-  { name: "AWS Lambda", level: "expert", category: "cloud" },
-  { name: "Apple Shortcuts", level: "expert", category: "automation" },
-  { name: "HTML/CSS", level: "expert", category: "programming" },
-  
-  // Advanced level (3)
-  { name: "AWS Glue", level: "advanced", category: "cloud" },
-  { name: "JavaScript", level: "advanced", category: "programming" },
-  { name: "React", level: "advanced", category: "programming" },
-  { name: "Next.js", level: "advanced", category: "programming" },
-  { name: "Node.js", level: "advanced", category: "programming" },
-  { name: "TypeScript", level: "advanced", category: "programming" },
-  { name: "Git", level: "advanced", category: "programming" },
-  { name: "GitHub Actions", level: "advanced", category: "cloud" },
-  { name: "Vercel", level: "advanced", category: "cloud" },
-  { name: "Tailwind CSS", level: "advanced", category: "programming" },
-  { name: "Mobile App Development", level: "advanced", category: "programming" },
-  { name: "SQL", level: "advanced", category: "programming" },
-  { name: "AWS EventBridge", level: "advanced", category: "cloud" },
-  
-  // Intermediate level (2)
-  { name: "AWS RDS", level: "intermediate", category: "cloud" },
-  { name: "AWS Step Functions", level: "intermediate", category: "cloud" },
+  { name: "AWS Bedrock", level: "intermediate", category: "ai" },
+  { name: "RAG/Embeddings", level: "intermediate", category: "ai" },
+  { name: "MCP (Model Context Protocol)", level: "expert", category: "ai" },
+  { name: "ChatGPT/OpenAI API", level: "expert", category: "ai" },
+  { name: "Prompt Engineering", level: "expert", category: "ai" },
+  { name: "LangChain", level: "intermediate", category: "ai" },
+  { name: "Streamlit", level: "intermediate", category: "ai" },
   { name: "PyTorch", level: "intermediate", category: "ai" },
   { name: "Transformers", level: "intermediate", category: "ai" },
-  { name: "Streamlit", level: "intermediate", category: "programming" },
-  { name: "MongoDB", level: "intermediate", category: "cloud" },
-  { name: "PostgreSQL", level: "intermediate", category: "cloud" },
-  { name: "PySpark", level: "intermediate", category: "cloud" },
-  { name: "Java", level: "intermediate", category: "programming" },
-  { name: "Swift", level: "intermediate", category: "programming" },
-  { name: "Kotlin", level: "intermediate", category: "programming" }
+  
+  // Other Tools
+  { name: "GitHub/GitHub Actions", level: "expert", category: "tools" },
+  { name: "Git", level: "advanced", category: "tools" },
+  { name: "N8N.io", level: "advanced", category: "tools" },
+  { name: "Postman", level: "advanced", category: "tools" },
+  { name: "Figma", level: "advanced", category: "tools" },
+  { name: "IAM Security", level: "expert", category: "tools" },
+  { name: "Airtable", level: "expert", category: "tools" },
+  { name: "Vercel", level: "advanced", category: "tools" },
+  { name: "MongoDB", level: "intermediate", category: "tools" },
+  
+  // Mobile & Automation
+  { name: "Apple Shortcuts", level: "expert", category: "mobile" },
+  { name: "iOS Development", level: "advanced", category: "mobile" },
+  { name: "Android Development", level: "advanced", category: "mobile" },
+  { name: "Swift", level: "intermediate", category: "mobile" },
+  { name: "Kotlin", level: "intermediate", category: "mobile" },
+  
+  // Web Development
+  { name: "JavaScript", level: "advanced", category: "web" },
+  { name: "TypeScript", level: "advanced", category: "web" },
+  { name: "React", level: "advanced", category: "web" },
+  { name: "Next.js", level: "advanced", category: "web" },
+  { name: "Node.js", level: "advanced", category: "web" },
+  { name: "Tailwind CSS", level: "advanced", category: "web" }
 ]
 
 const categories = {
-  programming: "Programming Languages",
-  cloud: "Cloud & Infrastructure", 
+  cloud: "Cloud & Infrastructure",
+  languages: "Languages & Libraries",
   ai: "AI & Development Tools",
-  design: "Design & Automation",
-  automation: "Workflow Automation"
+  tools: "Other Tools",
+  mobile: "Mobile & Automation",
+  web: "Web Development"
 }
 
 export function SkillsShowcase() {
@@ -87,10 +108,11 @@ export function SkillsShowcase() {
 
   const getLevelWidth = (level: string) => {
     switch (level) {
-      case 'expert': return 75
-      case 'advanced': return 60
-      case 'intermediate': return 45
-      default: return 25
+      case 'expert': return 100  // Score 4
+      case 'advanced': return 75  // Score 3
+      case 'intermediate': return 50  // Score 2
+      case 'beginner': return 25  // Score 1
+      default: return 0
     }
   }
 
@@ -99,6 +121,7 @@ export function SkillsShowcase() {
       case 'expert': return 'bg-gradient-to-r from-green-500 to-emerald-500'
       case 'advanced': return 'bg-gradient-to-r from-blue-500 to-cyan-500'
       case 'intermediate': return 'bg-gradient-to-r from-yellow-500 to-orange-500'
+      case 'beginner': return 'bg-gradient-to-r from-gray-400 to-gray-500'
       default: return 'bg-gradient-to-r from-gray-400 to-gray-500'
     }
   }


### PR DESCRIPTION
## Summary
- Fix 404 errors for project blog links
- Clean up skills to match resume exactly

## Changes Made

### Blog Links Fixed
- Added metadata for building-intelligent-chatbot-aws-bedrock
- Added metadata for enterprise-resource-management-system  
- Added metadata for ai-powered-portfolio-development
- Now all "Read More" buttons work correctly

### Skills Section Cleaned Up
- Removed skills not in resume (Windsurf AI, Zed AI, LangChain, etc.)
- Kept only 4 categories as shown in resume
- Apple Shortcuts is in "Other Tools" at expert level
- HTML/CSS is in "Languages & Libraries" at expert level
- All skills match resume page 4 exactly

## Test Plan
- [x] All blog links work without 404
- [x] Skills match resume exactly
- [x] Skill levels use correct scoring (4=expert, 3=advanced, 2=intermediate)